### PR TITLE
Allow "null" as coordinates of a canteen.

### DIFF
--- a/content/api/v2/canteens.md
+++ b/content/api/v2/canteens.md
@@ -39,7 +39,7 @@ address
 : **string** - A human readable real-world locator (vulgo _street address_).
 
 coordinates
-: **list of floats** (or **null**) - The coordinates of the canteen, gievn as list of latitude and longitude in north-eastern direction (negative values imply southern or western hemisphere). Can be null if coordinates are unknown.
+: **list of floats** (or **null**) - The coordinates of the canteen, given as list of latitude and longitude in north-eastern direction (negative values imply southern or western hemisphere). Can be null if coordinates are unknown.
 
 ### Examples
 

--- a/content/api/v2/canteens.md
+++ b/content/api/v2/canteens.md
@@ -29,6 +29,18 @@ ids
 <%= headers 200, :pagination => "canteens" %>
 <%= json :canteens %>
 
+id
+: **int** - The canteen's numeric ID, which identifys it uniquely within the API.
+
+name
+: **string** - The canteen's name.
+
+address
+: **string** - A human readable real-world locator (vulgo _street address_).
+
+coordinates
+: **list of floats** (or **null**) - The coordinates of the canteen, gievn as list of latitude and longitude in north-eastern direction (negative values imply southern or western hemisphere). Can be null if coordinates are unknown.
+
 ### Examples
 
 Return all canteens within a 5km radius around the Uni Potsdam canteen in Griebnitzsee.

--- a/lib/api_v2.rb
+++ b/lib/api_v2.rb
@@ -1,4 +1,4 @@
-module OpenMensa
+﻿module OpenMensa
   module Resources
   	module APIv2
       def self.headers(status, head = {})
@@ -23,11 +23,6 @@ module OpenMensa
       def self.curl(path, opts = {})
         %(<pre class="terminal"><code>$ curl -i http://openmensa.org/api/v2/#{path}</code></pre>)
       end
-
-      COORDINATES = [
-        52.1396188273019,
-        11.6475999355316
-      ]
 
       MEAL = {
         "id" => 260,
@@ -73,7 +68,7 @@ module OpenMensa
         "id" => 1,
         "name" => "Mensa UniCampus Magdeburg",
         "address" => "Pfälzer Str. 1, 39106 Magdeburg",
-        "coordinates" => COORDINATES
+        "coordinates" => nil
       }
 
       CANTEEN2 = {


### PR DESCRIPTION
Standardizes the behavior 'variant B' described in openmensa/openmensa#3
(which will soon be implemented in openmensa/openmensa by @mswart).