### PR TITLE
feed v2: improve and extend for meta data documentation

### DIFF
--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -167,7 +167,7 @@ The supported meta data have each its one tag, the following tags are supported:
 
 Opening types are defined via a `times` tag. It must have a `type` attribute with the value `opening`. We may later support other time ranges like meal serving times.
 
-The `times` tag should have 7 child elements (one per week day). If tags are omitted OpenMensa assumes that is was not possible to get a information for this particular day.
+The `times` tag should have 7 `open` child elements (one per week day). If tags are omitted OpenMensa assumes that is was not possible to get a information for this particular day.
 Each tag must have a `weekday` attribute with a value of the English weekday name (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
 
 For each week day place a `closed` tag to indicate that the canteen has not open at all.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -171,6 +171,6 @@ The `times` tag should have 7 `open` child elements (one per week day). If tags 
 Each tag must have a `weekday` attribute with a value of the English weekday name (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
 
 For each week day place a `closed` tag to indicate that the canteen has not open at all.
-Use a `open` tag with a value of `HH::mm-HH::mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
+Use a `open` tag with a value of `HH:mm-HH:mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
 
 Remember special closed days can be expressed via the [`closed` tag of days](#closed-days). Support of special opening times is currently not planed. Please contact OpenMensa if you have such a use case.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -10,10 +10,12 @@ As XML Schema: [http://openmensa.org/open-mensa-v2.xsd](http://openmensa.org/ope
 
 ## ChangeLog
 
-### Version 2.1 (2015-04-x)
+### Version 2.1 (2015-04-05, beta release)
 
 * [New version tag](#optional-version-element-since-version-21) to specify parser version
 * [Meta data attributes](#meta-data-since-version-21) like canteen name, address, contact info and information about different feeds for this canteen with its schedule information
+
+**Warning: The feed 2.1 is currently in implementation. Although we assume the schema remains unchanged, we may change details during the implementation.**
 
 ### Version 2.0 (2012-09-02)
 

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -18,19 +18,60 @@ If you build your feed's xml carefully (simply copy the first 5 lines from our e
 
 **If your feed is invalid with respect to our XML schema all contained data will be ignored! So keep your feed valid under all circumstances!**
 
-## Changes to [v1](/feed/v1/)
-
-* new *openmensa* root element
-* *name*s need to have less than 250 chars
-* rename cafeteria to *canteen*
-* price *role*s
-* closing times on day granularity
-
 ## *openmensa* root element
 
-A new root element with a more generic name that we want to preserve across future feed versions. The *version* attribute should equal 2.0.
+The root element is `openmensa`. It encapsulate all other attributes. This element will be preserved across future feed versions. The *version* attribute must equal 2.0.
 
-## Price roles
+## (optional) *version* element
+
+The top version tag is *optional*. It can be inserted to define the **version of the parser**. It has nothing to do with the canteen or its menu.
+
+Alternative the parser version can be return as `X-OpenMensa-ParserVersion` HTTP-Header. If both are provided, the HTTP-Header has precedence.
+
+The version itself is a normal string. OpenMensa does only check whether two versions are the same. There is relation derived from the versions. You are free to choose you matching version format.
+
+## *canteen* element
+
+This tag groups all data for one canteen. *Currently only one canteen per feed is supported*. Your feed must contain exactly one `canteen` tag. So to serve multiple canteens you need multiple feeds.
+
+### *day* elements
+
+Main part for the canteen are the `day` element. They need to have a `date` attribute formatting the date of this day in the `YYYY-MM-DD` format.
+
+There must only one day element per date. It is not required to provide tags for every day of a range. But be aware that OpenMensa does not process tags with past dates.
+
+#### closed days
+
+It is possible to explicit express that the canteen is (completely) closed on a given day. Add a empty `closed` tag as child.
+
+### *category* elements
+
+For each `day` the meals needs to be grouped by `category`. Each category tag needs to have a `name` attribute. The name is (only) displayed to the user and should be descriptive. But the categories only *group* the individual meals.
+
+Again a name can only used once a day, but is is normal to use the same or at least similar category names for each day.
+
+Common grouping is based on some product line or desk.
+
+A `category` is only allowed if no `closed` tag was provided - but then it is required to have at least one category. Each category needs to have at least on meal.
+
+
+## *meal* elements
+
+The `meal` element describes a meal or an individual purchasable entity that is available that the given day. A individual purchasable entry may be a side order.
+
+### *name*
+
+The important and the only required subelement is the `name` part. It should be a complete description of the meal. The name must not exceed 250 characters.The name of a meal, e.g. “Rinderhacksteak mit Kartoffeln”, shouldn’t be more than a couple of words or a sentence in maximum.
+
+### *notes*
+
+Additional text may go into several notes: A note often resembles a properties of the associated meal like the ingredients used or some important annotations.
+
+There is (currently) not restrictions on how the notes should look like or what are common notes. If you have a good proposal talk to us.
+
+### *price*
+
+For the meal the price can be expressed via (optional) `price` elements
 
 Because different prices may apply to different groups of people and we want to show, for which group we introduced several roles:
 
@@ -39,6 +80,67 @@ Because different prices may apply to different groups of people and we want to 
 * employees (of your organization
 * others (people that do not belong to your organization or to any other group listed here).
 
-## Closing times
+Please omit price for roles that are not applicable or the some as others.
 
-Instead of specifying one or more categories for a day, you can include only a *closed* for a *day* to explicitly indicate that a canteen has closed.
+
+## Meta data
+
+It is possible to provide a special meta data feed. This meta data are used to check whether the canteen meta data are still to-up-date (in case these data can be parsed/automatically received).
+
+The meta data are optional, they can be embedded within normal (menu) feeds, but they will be ignored on feed urls. On the other hand any returned day/menu data for a meta data url will also skipped.
+
+If a metadata url is provided, it is only required at at least on `feed` attribute is provided.
+
+### Example
+
+Before any further discussion, this is a (complete) example:
+
+<%= xml(file_in('static/meta_v2.xml')) %>
+
+
+### feeds
+
+A feed is basically only a URL. It is expected that OpenMensa gets a valid feed when requesting this URL.
+
+It is possible to define multiple feeds, because there may be menus that change often (e.g. the menu for the current day) and other that not. In additional if it parsing of one aspect fails, the other data should be served normally.
+
+It is required that each `feed` element contains one unique name. This name is only used by OpenMensa to match the given feed to previously saved feed data. But we recommend to choose descriptive names.
+
+#### *url* element
+
+The `url` element defines which page OpenMensa should request.
+
+#### *schedule* element
+
+The feed has a schedule element, that specify when this URL should be fetched.
+
+The require attributes `dayOfMonth`, `dayOfWeek`, `month`, `hour` and `minute` describes each a patter for the given unit. The feed is access if the current time matches **ALL** these patterns. It may take some minutes until the feed is fetched depending on the work load.
+
+The schedule behaviour and format is equal to `crontab`.
+
+Each pattern may be a `*` (for matches everything), `*/n` (matches every nth value, e.g. every seconds hour), or a comma separated list of individual numbers or ranges like `1,3-5`.
+
+The optional `retry` attributes defines how to handle errors. Without this attribute OpenMensa does not retry to fetch the feed on errors.
+
+The value must be a white-space separated list of positive numbers.
+
+The odd positioned one define an interval in *minutes*, the even positioned the maximal number of retried for this interval. If the last retry limit is omitted, OpenMensa retries until the next regular time.
+
+An example: `30 3` means retry maximal 3 time every half hour. `45 5 1440` means repeat first maximal 5 time every 45 minutes, if the feed fails still retry only once a day.
+
+#### *source* element
+
+You can provide a single URL, from that the data are (mostly) received. So in case of an error or a question, the user can be redirected to this page.
+
+### canteen meta data
+
+Each canteen attribute that can be edited on OpenMensa can also be provided via the feed. Changes via the feed are NOT used directly, but must be confirmed by one canteen admin. The author is informed about the changes via an email.
+
+The supported meta data have each its one tag, the following tags are supported:
+
+* **name**: the canteen name
+* **address**: the (postal) address. We do not require any special format. But the form `street nr, zip city` is common. If not geo coordinate for the canteen is provided the address is mapped to a point.
+* **city**: the user relevant city of this canteen. This does not need to be the postal city. The value is e.g. used to search canteens or group them.
+* **phone**: the telephone number to contact the canteen; nor specific format is required, but *recommend* TODO
+* **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value within the ?? coordinate system. The tag must not contain any content.
+* To indicate whether the canteen can be used by everyone (**public**) or not (**restricted**), one of the two `public`, `restricted` tags can be used. Both must not have any content.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -137,7 +137,7 @@ The `url` element defines which page OpenMensa should request.
 
 The feed has a schedule element, that specify when this URL should be fetched.
 
-The require attributes `dayOfMonth`, `dayOfWeek`, `month`, `hour` and `minute` describes each a patter for the given unit. The feed is access if the current time matches **ALL** these patterns. It may take some minutes until the feed is fetched depending on the work load.
+The attributes `dayOfMonth`, `dayOfWeek`, `month`, `hour` and `minute` describes each a patter for the given unit. The feed is accessed if the current time matches **ALL** these patterns. It may take some minutes until the feed is fetched depending on the work load.
 
 The schedule behaviour and format is equal to `crontab`.
 
@@ -145,11 +145,11 @@ Each pattern may be a comma separated list of individual numbers or ranges like 
 
 The special range `*` means all possible values. A range can be followed by a `/<number>` to specify to only match the nth value within the range. `0-23/2` matches `0,2,4,6,8,10,12,14,16,18,20,22`.
 
-Only the `hour` attribute is required, `dayOfMonth`, `dayOfWeek` and `month` defaults to `*`, `minute` to `0`.
+Only the `hour` attribute is required, `dayOfMonth`, `dayOfWeek` and `month` default to `*`, `minute` to `0`.
 
 `dayOfMonth` starts with `1`, `dayOfWeek` with `0` meaning Sunday (`1` Monday ...).
 
-The optional `retry` attributes defines how to handle errors. Without this attribute OpenMensa does not retry to fetch the feed on errors.
+The optional `retry` attribute defines how to handle errors. Without this attribute OpenMensa does not retry to fetch the feed on errors.
 
 The value must be a white-space separated list of positive numbers.
 

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -43,7 +43,7 @@ The top version tag is *optional*. It can be inserted to define the **version of
 
 Alternative the parser version can be return as `X-OpenMensa-ParserVersion` HTTP-Header. If both are provided, the value from the XML has precedence.
 
-The version itself is a normal string. OpenMensa does only check whether two versions are the same. There is relation derived from the versions. You are free to choose you matching version format.
+The version itself is a normal string that must not exceed 63 characters. OpenMensa does only check whether two versions are the same. There is relation derived from the versions. You are free to choose your matching version format.
 
 ## *canteen* element
 

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -171,6 +171,6 @@ The `times` tag should have 7 `open` child elements (one per week day). If tags 
 Each tag must have a `weekday` attribute with a value of the English weekday name (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
 
 For each week day place a `closed` tag to indicate that the canteen has not open at all.
-Use a `open` tag with a value of `HH:mm-HH:mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
+Use a `open` tag with a `time` attribute of `HH:mm-HH:mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
 
 Remember special closed days can be expressed via the [`closed` tag of days](#closed-days). Support of special opening times is currently not planed. Please contact OpenMensa if you have such a use case.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -8,6 +8,21 @@ title: OpenMensa Feed v2
 
 As XML Schema: [http://openmensa.org/open-mensa-v2.xsd](http://openmensa.org/open-mensa-v2.xsd)
 
+## ChangeLog
+
+### Version 2.1 (2015-04-x)
+
+* [New version tag](#optional-version-element-since-version-21) to specify parser version
+* [Meta data attributes](#meta-data-since-version-21) like canteen name, address, contact info and information about different feeds for this canteen with its schedule information
+
+### Version 2.0 (2012-09-02)
+
+* [new *openmensa* root element](#openmensa-root-element)
+* [*name*s need to have less than 250 chars](#name)
+* [rename cafeteria to *canteen*](#canteen-element)
+* [price *role*s](#price)
+* [closing times on day granularity](#closed-days)
+
 ## Example
 
 <%= xml(file_in('static/feed_v2.xml')) %>
@@ -20,13 +35,13 @@ If you build your feed's xml carefully (simply copy the first 5 lines from our e
 
 ## *openmensa* root element
 
-The root element is `openmensa`. It encapsulate all other attributes. This element will be preserved across future feed versions. The *version* attribute must equal 2.0.
+The root element is `openmensa`. It encapsulate all other attributes. This element will be preserved across future feed versions. The *version* attribute must equal `2.0` or `2.1`.
 
-## (optional) *version* element
+## (optional) *version* element (since version 2.1)
 
 The top version tag is *optional*. It can be inserted to define the **version of the parser**. It has nothing to do with the canteen or its menu.
 
-Alternative the parser version can be return as `X-OpenMensa-ParserVersion` HTTP-Header. If both are provided, the HTTP-Header has precedence.
+Alternative the parser version can be return as `X-OpenMensa-ParserVersion` HTTP-Header. If both are provided, the value from the XML has precedence.
 
 The version itself is a normal string. OpenMensa does only check whether two versions are the same. There is relation derived from the versions. You are free to choose you matching version format.
 
@@ -83,7 +98,7 @@ Because different prices may apply to different groups of people and we want to 
 Please omit price for roles that are not applicable or the some as others.
 
 
-## Meta data
+## Meta data (since version 2.1)
 
 It is possible to provide a special meta data feed. This meta data are used to check whether the canteen meta data are still to-up-date (in case these data can be parsed/automatically received).
 
@@ -142,5 +157,5 @@ The supported meta data have each its one tag, the following tags are supported:
 * **address**: the (postal) address. We do not require any special format. But the form `street nr, zip city` is common. If not geo coordinate for the canteen is provided the address is mapped to a point.
 * **city**: the user relevant city of this canteen. This does not need to be the postal city. The value is e.g. used to search canteens or group them.
 * **email** / **phone**: an email address respectively the phone number to contact the canteen. We do not ensure a specific format: the main purpose is that is understandable for humans, but we highly recommend following the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
-* **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value within the ?? coordinate system. The tag must not contain any content.
+* **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value. The tag must not contain any content.
 * **availability**: indicate whether the canteen can be used by everyone (**public**) or not (**restricted**)

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -141,6 +141,6 @@ The supported meta data have each its one tag, the following tags are supported:
 * **name**: the canteen name
 * **address**: the (postal) address. We do not require any special format. But the form `street nr, zip city` is common. If not geo coordinate for the canteen is provided the address is mapped to a point.
 * **city**: the user relevant city of this canteen. This does not need to be the postal city. The value is e.g. used to search canteens or group them.
-* **phone**: the telephone number to contact the canteen; nor specific format is required, but *recommend* TODO
+* **email** / **phone**: an email address respectively the phone number to contact the canteen. We do not ensure a specific format: the main purpose is that is understandable for humans, but we highly recommend following the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
 * **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value within the ?? coordinate system. The tag must not contain any content.
-* To indicate whether the canteen can be used by everyone (**public**) or not (**restricted**), one of the two `public`, `restricted` tags can be used. Both must not have any content.
+* **availability**: indicate whether the canteen can be used by everyone (**public**) or not (**restricted**)

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -37,6 +37,8 @@ If you build your feed's xml carefully (simply copy the first 5 lines from our e
 
 The root element is `openmensa`. It encapsulate all other attributes. This element will be preserved across future feed versions. The *version* attribute must equal `2.0` or `2.1`.
 
+Which version you choose is not technically difference. OpenMensa supports all v2 features independent of the chosen version. We distinguish between the versions to raise errors on to old server schemas and to know which feature set is probably known/implemented.
+
 ## (optional) *version* element (since version 2.1)
 
 The top version tag is *optional*. It can be inserted to define the **version of the parser**. It has nothing to do with the canteen or its menu.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -104,9 +104,11 @@ Please omit price for roles that are not applicable or the some as others.
 
 It is possible to provide a special meta data feed. This meta data are used to check whether the canteen meta data are still to-up-date (in case these data can be parsed/automatically received).
 
-The meta data are optional, they can be embedded within normal (menu) feeds, but they will be ignored on feed urls. On the other hand any returned day/menu data for a meta data url will also skipped.
+The meta data are optional, they can be embedded within normal (menu) feeds, but they will be ignored on feed URLs. On the other hand any returned day/menu data for a meta data URL will also skipped.
 
-If a metadata url is provided, it is only required at at least on `feed` attribute is provided.
+**You must ensure that the elements within the canteen are order like: `name`, `address`, `city`, `phone`, `email`, `location`, `availability`, `times`, `feed`, `day`!**
+
+If a meta data URL is provided, it is only required at at least on `feed` attribute is provided.
 
 ### Example
 
@@ -121,13 +123,15 @@ A feed is basically only a URL. It is expected that OpenMensa gets a valid feed 
 
 It is possible to define multiple feeds, because there may be menus that change often (e.g. the menu for the current day) and other that not. In additional if it parsing of one aspect fails, the other data should be served normally.
 
-It is required that each `feed` element contains one unique name. This name is only used by OpenMensa to match the given feed to previously saved feed data. But we recommend to choose descriptive names.
+It is required that each `feed` element contains one unique `name` attribute. This name is only used by OpenMensa to match the given feed to previously saved feed data. But we recommend to choose descriptive names.
+
+The optional `priority` attribute defines override rules between different feeds for a canteen. All feeds have per default the `priority` `0`. A feed can update/remove a meal if the priority is same or greater than the priority of the feed that created the menu. A example usage: use priority `0` for the full feed, but use `10` for the `today` feed - today data have priority and can not be overridden by the normal feed.
 
 #### *url* element
 
 The `url` element defines which page OpenMensa should request.
 
-#### *schedule* element
+#### (optional) *schedule* element
 
 The feed has a schedule element, that specify when this URL should be fetched.
 
@@ -135,7 +139,13 @@ The require attributes `dayOfMonth`, `dayOfWeek`, `month`, `hour` and `minute` d
 
 The schedule behaviour and format is equal to `crontab`.
 
-Each pattern may be a `*` (for matches everything), `*/n` (matches every nth value, e.g. every seconds hour), or a comma separated list of individual numbers or ranges like `1,3-5`.
+Each pattern may be a comma separated list of individual numbers or ranges like `1,3-5`. Range are inclusive.
+
+The special range `*` means all possible values. A range can be followed by a `/<number>` to specify to only match the nth value within the range. `0-23/2` matches `0,2,4,6,8,10,12,14,16,18,20,22`.
+
+Only the `hour` attribute is required, `dayOfMonth`, `dayOfWeek` and `month` defaults to `*`, `minute` to `0`.
+
+`dayOfMonth` starts with `1`, `dayOfWeek` with `0` meaning Sunday (`1` Monday ...).
 
 The optional `retry` attributes defines how to handle errors. Without this attribute OpenMensa does not retry to fetch the feed on errors.
 
@@ -145,13 +155,15 @@ The odd positioned one define an interval in *minutes*, the even positioned the 
 
 An example: `30 3` means retry maximal 3 time every half hour. `45 5 1440` means repeat first maximal 5 time every 45 minutes, if the feed fails still retry only once a day.
 
-#### *source* element
+If the `schedule` element is omitted, the feed can only be used for manual fetching. OpenMensa has no implicit scheduling for feeds.
+
+#### (optional) *source* element
 
 You can provide a single URL, from that the data are (mostly) received. So in case of an error or a question, the user can be redirected to this page.
 
 ### canteen meta data
 
-Each canteen attribute that can be edited on OpenMensa can also be provided via the feed. Changes via the feed are NOT used directly, but must be confirmed by one canteen admin. The author is informed about the changes via an email.
+Each canteen attribute that can be edited on OpenMensa can also be provided via the feed. Changes via the feed are NOT used directly, but must be confirmed by one canteen administration. The author is informed about the changes via an email.
 
 The supported meta data have each its one tag, the following tags are supported:
 
@@ -168,9 +180,10 @@ The supported meta data have each its one tag, the following tags are supported:
 Opening types are defined via a `times` tag. It must have a `type` attribute with the value `opening`. We may later support other time ranges like meal serving times.
 
 The `times` tag should have 7 `open` child elements (one per week day). If tags are omitted OpenMensa assumes that is was not possible to get a information for this particular day.
-Each tag must have a `weekday` attribute with a value of the English weekday name (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
+The elements name are the English weekday name: `monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`. *You must ensure a correct ordering.*
 
-For each week day place a `closed` tag to indicate that the canteen has not open at all.
-Use a `open` tag with a `time` attribute of `HH:mm-HH:mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
+Set the `closed` attribute to `true`  indicate that the canteen has not open at all.
+Use a `open` attribute of `HH:mm-HH:mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
+*`closed` and `open` attribute must not used both!*
 
 Remember special closed days can be expressed via the [`closed` tag of days](#closed-days). Support of special opening times is currently not planed. Please contact OpenMensa if you have such a use case.

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -156,10 +156,10 @@ Each canteen attribute that can be edited on OpenMensa can also be provided via 
 The supported meta data have each its one tag, the following tags are supported:
 
 * **name**: the canteen name
-* **address**: the (postal) address. We do not require any special format. But the form `street nr, zip city` is common. If not geo coordinate for the canteen is provided the address is mapped to a point.
+* **address**: the (postal) address. We do not require any special format. But the form `street nr, zip city` is common. If no geo coordinate for the canteen is provided the address is mapped to a point.
 * **city**: the user relevant city of this canteen. This does not need to be the postal city. The value is e.g. used to search canteens or group them.
 * **email** / **phone**: an email address respectively the phone number to contact the canteen. We do not ensure a specific format: the main purpose is that is understandable for humans, but we highly recommend following the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
-* **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value. The tag must not contain any content.
+* **location**: the geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value. The tag must not contain any content.
 * **availability**: indicate whether the canteen can be used by everyone (**public**) or not (**restricted**)
 * **opening times**: see next section
 

--- a/content/feed/v2.md
+++ b/content/feed/v2.md
@@ -159,3 +159,16 @@ The supported meta data have each its one tag, the following tags are supported:
 * **email** / **phone**: an email address respectively the phone number to contact the canteen. We do not ensure a specific format: the main purpose is that is understandable for humans, but we highly recommend following the [E.123](http://en.wikipedia.org/wiki/E.123) standard.
 * **location**: The geo coordinates can be passed an `latitude` and a `longitude` attribute. Each attribute needs to be a float value. The tag must not contain any content.
 * **availability**: indicate whether the canteen can be used by everyone (**public**) or not (**restricted**)
+* **opening times**: see next section
+
+#### opening times
+
+Opening types are defined via a `times` tag. It must have a `type` attribute with the value `opening`. We may later support other time ranges like meal serving times.
+
+The `times` tag should have 7 child elements (one per week day). If tags are omitted OpenMensa assumes that is was not possible to get a information for this particular day.
+Each tag must have a `weekday` attribute with a value of the English weekday name (`monday`, `tuesday`, `wednesday`, `thursday`, `friday`, `saturday`, `sunday`).
+
+For each week day place a `closed` tag to indicate that the canteen has not open at all.
+Use a `open` tag with a value of `HH::mm-HH::mm` to specify that the canteen has open within the given time interval. Please contact OpenMensa if you need to specify due intervals / express a pause.
+
+Remember special closed days can be expressed via the [`closed` tag of days](#closed-days). Support of special opening times is currently not planed. Please contact OpenMensa if you have such a use case.

--- a/static/feed_v2.xml
+++ b/static/feed_v2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openmensa version="2.0"
+<openmensa version="2.1"
            xmlns="http://openmensa.org/open-mensa-v2"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">

--- a/static/feed_v2.xml
+++ b/static/feed_v2.xml
@@ -3,9 +3,10 @@
            xmlns="http://openmensa.org/open-mensa-v2"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">
+  <version>5.04-4</version>
   <canteen>
     <day date="2012-05-29">
-      <category name="Essen 1">
+      <category name="Hauptgericht">
         <meal>
           <name>Rührei mit Rahmspinat und Salzkartoffeln</name>
           <note>ovo-lacto-vegetabil</note>
@@ -13,14 +14,18 @@
           <price role="employee">2.60</price>
           <price role="other">3.00</price>
         </meal>
-      </category>
-      <category name="Essen 2">
         <meal>
           <name>Hähnchengeschnetzeltes mit exotischen Früchten, dazu Bio-Reis und Mischsalat</name>
           <note>mit Geflügelfleisch</note>
           <price role="student">2.00</price>
           <price role="employee">3.35</price>
           <price role="other">4.00</price>
+        </meal>
+      </category>
+      <category name="Sonstiges">
+        <meal>
+          <name>Spargelcremsuppe</name>
+          <price role="other">2.00</price>
         </meal>
       </category>
     </day>

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -12,13 +12,13 @@
     <location latitude="52.3935353446923" longitude="13.1278145313263" />
     <availability>public</availability>
     <times type="opening">
-      <open weekday="monday" time="11:00-14:00" />
-      <open weekday="tuesday" time="11:00-14:00" />
-      <open weekday="wednesday" time="11:00-14:00" />
-      <open weekday="thursday" time="11:00-14:00" />
-      <open weekday="friday" time="11:00-14:00" />
-      <open weekday="saturday" time="11:00-13:30" />
-      <closed weekday="sunday" />
+      <monday open="11:00-14:00" />
+      <tuesday open="11:00-14:00" />
+      <wednesday open="11:00-14:00" />
+      <thursday open="11:00-14:00" />
+      <friday open="11:00-14:00" />
+      <saturday open="11:00-13:30" />
+      <sunday closed="true" />
     </times>
     <feed name="today" priority="0">
       <!-- cron like schedule information -->

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -12,12 +12,12 @@
     <location latitude="52.3935353446923" longitude="13.1278145313263" />
     <availability>public</availability>
     <times type="opening">
-      <open weekday="monday">11:00-14:00</open>
-      <open weekday="tuesday">11:00-14:00</open>
-      <open weekday="wednesday">11:00-14:00</open>
-      <open weekday="thursday">11:00-14:00</open>
-      <open weekday="friday">11:00-14:00</open>
-      <open weekday="saturday">11:00-13:30</open>
+      <open weekday="monday" time="11:00-14:00" />
+      <open weekday="tuesday" time="11:00-14:00" />
+      <open weekday="wednesday" time="11:00-14:00" />
+      <open weekday="thursday" time="11:00-14:00" />
+      <open weekday="friday" time="11:00-14:00" />
+      <open weekday="saturday" time="11:00-13:30" />
       <closed weekday="sunday" />
     </times>
     <feed name="today" priority="0">

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -11,6 +11,15 @@
     <phone>(0331) 977 3749/3748</phone>
     <location latitude="52.3935353446923" longitude="13.1278145313263" />
     <public />
+    <times type="opening">
+      <open weekday="monday">11:00-14:00</open>
+      <open weekday="tuesday">11:00-14:00</open>
+      <open weekday="wednesday">11:00-14:00</open>
+      <open weekday="thursday">11:00-14:00</open>
+      <open weekday="friday">11:00-14:00</open>
+      <open weekday="saturday">11:00-13:30</open>
+      <closed weekday="sunday" />
+    </times>
     <feed name="today" priority="0">
       <!-- cron like schedule information -->
       <schedule dayOfMonth="*" dayOfWeek="*" hour="8-14" retry="30 1" />

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openmensa version="2.0"
+           xmlns="http://openmensa.org/open-mensa-v2"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">
+  <version>5.04-4</version>
+  <canteen>
+    <name>Mensa Griebnitzsee</name>
+    <address>August-Bebel-Str. 89, 14482 Potsdam</address>
+    <city>Potsdam</city>
+    <phone>(0331) 977 3749/3748</phone>
+    <location latitude="52.3935353446923" longitude="13.1278145313263" />
+    <public />
+    <feed name="today" priority="0">
+      <!-- cron like schedule information -->
+      <schedule dayOfMonth="*" dayOfWeek="*" hour="8-14" retry="30 1" />
+      <url>http://kaifabian.de/om/potsdam/griebnitzsee.xml?today</url>
+      <source>http://www.studentenwerk-potsdam.de/mensa-griebnitzsee.html</source>
+    </feed>
+    <feed name="full" priority="1">
+      <schedule dayOfMonth="*" dayOfWeek="1" hour="8" retry="60 5 1440" />
+      <url>http://kaifabian.de/om/potsdam/griebnitzsee.xml</url>
+      <source>http://www.studentenwerk-potsdam.de/speiseplan/</source>
+    </feed>
+  </canteen>
+</openmensa>

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<openmensa version="2.0"
+<openmensa version="2.1"
            xmlns="http://openmensa.org/open-mensa-v2"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://openmensa.org/open-mensa-v2 http://openmensa.org/open-mensa-v2.xsd">

--- a/static/meta_v2.xml
+++ b/static/meta_v2.xml
@@ -10,7 +10,7 @@
     <city>Potsdam</city>
     <phone>(0331) 977 3749/3748</phone>
     <location latitude="52.3935353446923" longitude="13.1278145313263" />
-    <public />
+    <availability>public</availability>
     <times type="opening">
       <open weekday="monday">11:00-14:00</open>
       <open weekday="tuesday">11:00-14:00</open>


### PR DESCRIPTION
Extend the feed for meta data as discussed in openmensa/openmensa#4.

Open for comments. Anything unclear or unclear expressed. Feel free to mark/correct typos and grammar errors.

I have the two open questions:
- [x] Which telephone format do we want to recommend? If you prefer a every + very common one (`0331 977-3749`)
- [x] how is the coordinate system named we need coordinates for
- [x] is the naming `public` / `restricted` better?